### PR TITLE
Fix JS example to receive eventbus bridge messages

### DIFF
--- a/vertx-web/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-web/src/main/asciidoc/groovy/index.adoc
@@ -2252,7 +2252,7 @@ var eb = new EventBus('http://localhost:8080/eventbus');
 eb.onopen = function() {
 
   // set a handler to receive a message
-  eb.registerHandler('some-address', function(message) {
+  eb.registerHandler('some-address', function(err, message) {
     console.log('received a message: ' + JSON.stringify(message);
   });
 


### PR DESCRIPTION
There appears to be an error in the code for the example to send and receive client side messages in Javascript over the eventbus bridge. As written, every message logged to the console is null. In order to make the example work I needed to add another parameter before the 'message' parameter so that it matches the source code for the onmessage function in vertx-eventbus.js on lines 131 and 141. There, the onmessage function has two calls which pass two arguments to a handler, and the arguments are '(null, json)'. I believe the first argument 'null' is to indicate an error has not occurred.

When my client code matched the example in the Asciidoc and only had one argument, the json message was always arriving as null. My proposed fix to the example code allows the proper json message to be received by my client's handler.
